### PR TITLE
Added Origin header handling

### DIFF
--- a/wsclient.h
+++ b/wsclient.h
@@ -127,7 +127,8 @@ void libwsclient_onopen(wsclient *client, int (*cb)(wsclient *c));
 void libwsclient_onmessage(wsclient *client, int (*cb)(wsclient *c, wsclient_message *msg));
 void libwsclient_onerror(wsclient *client, int (*cb)(wsclient *c, wsclient_error *err));
 
-wsclient *libwsclient_new(const char *URI, const char *origin);
+wsclient *libwsclient_new(const char *URI);
+wsclient *libwsclient_new_extra(const char *URI, const char *origin);
 wsclient_error *libwsclient_new_error(int errcode);
 ssize_t _libwsclient_read(wsclient *c, void *buf, size_t length);
 ssize_t _libwsclient_write(wsclient *c, const void *buf, size_t length);

--- a/wsclient.h
+++ b/wsclient.h
@@ -115,6 +115,7 @@ typedef struct _wsclient {
 	SSL_CTX *ssl_ctx;
 	SSL *ssl;
 #endif
+	char *origin;
 } wsclient;
 
 
@@ -126,7 +127,7 @@ void libwsclient_onopen(wsclient *client, int (*cb)(wsclient *c));
 void libwsclient_onmessage(wsclient *client, int (*cb)(wsclient *c, wsclient_message *msg));
 void libwsclient_onerror(wsclient *client, int (*cb)(wsclient *c, wsclient_error *err));
 
-wsclient *libwsclient_new(const char *URI);
+wsclient *libwsclient_new(const char *URI, const char *origin);
 wsclient_error *libwsclient_new_error(int errcode);
 ssize_t _libwsclient_read(wsclient *c, void *buf, size_t length);
 ssize_t _libwsclient_write(wsclient *c, const void *buf, size_t length);


### PR DESCRIPTION
A new function `wsclient *libwsclient_new_extra(const char *URI, const char *origin);` was added, which allows the user to specify the Origin header. Additionally, handshake failure is now ignored, allowing communication with misconfigured servers.